### PR TITLE
Move dump scripts from phosphor-debug-collector

### DIFF
--- a/dump/tools/bmcdump/badpel
+++ b/dump/tools/bmcdump/badpel
@@ -1,0 +1,14 @@
+#!/ usr / bin / env bash
+#
+#config : 2 20
+#@brief : Save the 'badPEL' file
+#
+
+.$DREPORT_INCLUDE / functions
+
+                        desc = "Bad PEL file" file_name =
+    "/var/lib/phosphor-logging/extensions/pels/badPEL"
+
+    if[-e "$file_name"];
+then add_copy_file "$file_name"
+                   "$desc" fi

--- a/dump/tools/bmcdump/cfam
+++ b/dump/tools/bmcdump/cfam
@@ -1,0 +1,29 @@
+#!/ usr / bin / env bash
+#
+#config : 234 10
+#@brief : Add CFAM details to dump.
+#
+
+#shellcheck disable = SC1091
+."$DREPORT_INCLUDE" /
+        functions
+
+            source /
+        etc / profile.d / power -
+    target.sh
+
+        file_name = "cfam.log" if[-e "/usr/bin/edbg"];
+then desc = "cfam 283c" command =
+    "/usr/bin/edbg getcfam pu 283c -pall" add_cmd_output "$command"
+    "$file_name"
+    "$desc"
+
+    desc = "cfam 1007" command =
+        "/usr/bin/edbg getcfam pu 1007 -pall" add_cmd_output "$command"
+        "$file_name"
+        "$desc"
+
+    desc = "cfam 2809" command =
+        "/usr/bin/edbg getcfam pu 2809 -pall" add_cmd_output "$command"
+        "$file_name"
+        "$desc" fi

--- a/dump/tools/bmcdump/dumpfilelist
+++ b/dump/tools/bmcdump/dumpfilelist
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# config: 2 30
+# @brief: Get the dump and core file information
+#
+
+# shellcheck disable=SC1091
+. "$DREPORT_INCLUDE"/functions
+
+#core files
+file_name="dumplist.log"
+desc="Dumps"
+command="busctl call --verbose --no-pager \
+                xyz.openbmc_project.Dump.Manager \
+                /xyz/openbmc_project/dump \
+                org.freedesktop.DBus.ObjectManager \
+                GetManagedObjects"
+if ! add_cmd_output "$command" "$file_name" "$desc";
+then
+    #bmc dumps
+    dir="/var/lib/phosphor-debug-collector/dumps/"
+    desc="BMC dumps"
+    if [ -d "$dir" ] && [ -n "$(ls -A $dir/)" ]; then
+        add_cmd_output "echo $'[$desc]'" "$file_name" "$desc"
+        add_cmd_output "ls -AX $dir/*/*" "$file_name" "$desc"
+    else
+        log_info "$desc directory is empty"
+    fi
+
+    #hardware dumps
+    dir="/var/lib/phosphor-debug-collector/hardwaredump/"
+    desc="Hardware dumps"
+    if [ -d "$dir" ] && [ -n "$(ls -A $dir/)" ]; then
+        add_cmd_output "echo $'\n[$desc]'" "$file_name" "$desc"
+        add_cmd_output "ls -AX $dir/*/*" "$file_name" "$desc"
+    else
+        log_info "$desc directory is empty"
+    fi
+
+
+    #hostboot dumps
+    dir="/var/lib/phosphor-debug-collector/hostbootdump/"
+    desc="Hostboot dumps"
+    if [ -d "$dir" ] && [ -n "$(ls -A $dir/)" ]; then
+        add_cmd_output "echo $'\n[$desc]'" "$file_name" "$desc"
+        add_cmd_output "ls -AX $dir/*/*" "$file_name" "$desc"
+    else
+        log_info "$desc directory is empty"
+    fi
+
+
+    #sbe dumps
+    dir="/var/lib/phosphor-debug-collector/sbedump/"
+    desc="SBE dumps"
+    if [ -d "$dir" ] && [ -n "$(ls -A $dir/)" ]; then
+        add_cmd_output "echo $'\n[$desc]'" "$file_name" "$desc"
+        add_cmd_output "ls -AX $dir/*/*" "$file_name" "$desc"
+    else
+        log_info "$desc directory is empty"
+    fi
+fi
+
+#capture core file list
+dir="/var/lib/systemd/coredump/"
+desc="core files"
+if [ -d "$dir" ] && [ -n "$(ls -A $dir/)" ] && [ -n "$(ls -A $dir/core*)" ]; then
+    add_cmd_output "echo $'[$desc]'" "$file_name" "$desc"
+    add_cmd_output "ls -AX $dir/core*" "$file_name" "$desc"
+else
+    log_info "$desc directory is empty"
+fi
+

--- a/dump/tools/bmcdump/gendumpheader
+++ b/dump/tools/bmcdump/gendumpheader
@@ -1,0 +1,361 @@
+#!/bin/bash
+#
+#Header for BMC DUMP
+#This script will create header file only for IBM systems.
+#This script will generate generic IBM dump header format.
+#
+#Note: The dump header will be imposed on the dump file i.e
+#<obmdump file>.tar.xz only on IBM specific systems, user needs to
+#separate out the header before extracting the dump.
+#
+
+#Constants
+declare -rx INVENTORY_MANAGER='xyz.openbmc_project.Inventory.Manager'
+declare -rx INVENTORY_PATH='/xyz/openbmc_project/inventory/system'
+declare -rx INVENTORY_ASSET_INT='xyz.openbmc_project.Inventory.Decorator.Asset'
+declare -rx DUMP_HEADER_ENTRY_SIZE='516'
+declare -rx INVENTORY_BMC_BOARD='/xyz/openbmc_project/inventory/system/chassis/motherboard'
+declare -rx SIZE_4='4'
+declare -rx SIZE_8='8'
+declare -rx SIZE_12='12'
+declare -rx SIZE_32='32'
+
+#Variables
+declare -x FILE="/tmp/dumpheader_$EPOCHTIME"
+declare -x dumpSize=$(ls -al $name_dir.tar.xz | awk '{print $5}')
+<<<<<<< HEAD
+<<<<<<< HEAD
+declare -x modelNo=$(busctl get-property $INVENTORY_MANAGER $INVENTORY_PATH \
+=======
+declare -x modelNo
+modelNo=$(busctl get-property $INVENTORY_MANAGER $INVENTORY_PATH \
+>>>>>>> 4e9a7ae (dreport:IBM: Added custom package script)
+    $INVENTORY_ASSET_INT Model | cut -d " " -f 2 | sed "s/^\(\"\)\(.*\)\1\$/\2/g")
+declare -rx OP_DUMP="opdump"
+declare -rx INVENTORY_MANAGER='xyz.openbmc_project.Inventory.Manager'
+declare -rx INVENTORY_PATH='/xyz/openbmc_project/inventory/system'
+declare -rx INVENTORY_ASSET_INT='xyz.openbmc_project.Inventory.Decorator.Asset'
+declare -rx INVENTORY_BMC_BOARD='/xyz/openbmc_project/inventory/system/chassis/motherboard'
+
+#Variables
+declare -x FILE="/tmp/dumpheader_$EPOCHTIME"
+declare -x serialNo
+serialNo=$(busctl get-property $INVENTORY_MANAGER $INVENTORY_PATH \
+    $INVENTORY_ASSET_INT SerialNumber | cut -d " " -f 2 | sed "s/^\(\"\)\(.*\)\1\$/\2/g")
+
+declare -x dDay=$(date -d @$EPOCHTIME +'%Y%m%d%H%M%S')
+
+declare -x bmcSerialNo=$(busctl call $INVENTORY_MANAGER $INVENTORY_BMC_BOARD \
+        org.freedesktop.DBus.Properties Get ss $INVENTORY_ASSET_INT \
+    SerialNumber | cut -d " " -f 3 | sed "s/^\(\"\)\(.*\)\1\$/\2/g")
+=======
+declare -x modelNo
+#Variables
+declare -x serialNo
+serialNo=$(busctl get-property $INVENTORY_MANAGER $INVENTORY_PATH \
+    $INVENTORY_ASSET_INT SerialNumber | cut -d " " -f 2 | sed "s/^\(\"\)\(.*\)\1\$/\2/g")
+declare -x dDay
+dDay=$(date -d @"$EPOCHTIME" +'%Y%m%d%H%M%S')
+declare -x bmcSerialNo
+>>>>>>> cac02c7 (dreport: Adding default value to model & serial number)
+
+#Function to add NULL
+function add_null() {
+    local a=$1
+    printf '%*s' $a | tr ' ' "\0" >> $FILE
+}
+
+#Function to is to convert the EPOCHTIME collected
+#from dreport into hex values and write the same in
+#header.
+function dump_time() {
+    x=${#dDay}
+    msize=`expr $x / 2`
+    msize=`expr $SIZE_8 - $msize`
+    for ((i=0;i<$x;i+=2));
+    do
+        printf \\x${dDay:$i:2} >> $FILE
+    done
+    add_null $msize
+}
+
+#Function to fetch the size of the dump
+function dump_size() {
+    #Adding 516 bytes as the total dump size is dump tar size
+    #plus the dump header entry in this case
+    #dump_header and dump_entry
+    # shellcheck disable=SC2154 # name_dir comes from elsewhere.
+    dumpSize=$(stat -c %s "$name_dir.bin")
+    sizeDump=$(( dumpSize + DUMP_HEADER_ENTRY_SIZE ))
+    printf -v hex "%x" "$sizeDump"
+    x=${#hex}
+    if [ $(($x % 2)) -eq 1 ]; then
+        hex=0$hex
+        x=${#hex}
+    fi
+    msize=`expr $x / 2`
+    msize=`expr $SIZE_8 - $msize`
+    add_null $msize
+    for ((i=0;i<$x;i+=2));
+    do
+        printf \\x${hex:$i:2} >> $FILE
+    done
+}
+
+#Function to set dump id to 8 bytes format
+function get_dump_id() {
+    x=${#dump_id}
+    nulltoadd=`expr $SIZE_8 - $x`
+    printf '%*s' $nulltoadd | tr ' ' "0" >> $FILE
+    printf $dump_id >> $FILE
+}
+
+#Function to get the bmc serial number
+function getbmc_serial() {
+    x=${#bmcSerialNo}
+    nulltoadd=`expr $SIZE_12 - $x`
+    printf $bmcSerialNo >> $FILE
+    printf '%*s' $nulltoadd | tr ' ' "0" >> $FILE
+}
+
+#Function to fetch the hostname
+function system_name() {
+    name=$(hostname)
+    len=${#name}
+    nulltoadd=$(( SIZE_32 - len ))
+    printf "%s" "$name" >> "$FILE"
+    add_null "$nulltoadd"
+}
+
+#Function to get the errorlog ID
+function get_eid() {
+    # shellcheck disable=SC2154 # dump_type comes from elsewhere
+    if [ "$dump_type" = "$OP_DUMP" ]; then
+        # shellcheck disable=SC2154 # elog_id comes from elsewhere
+        x=${#elog_id}
+        msize=$(( x / 2 ))
+        msize=$(( SIZE_4 - msize ))
+        for ((i=0;i<x;i+=2));
+        do
+            printf "\\x${elog_id:$i:2}" >> "$FILE"
+        done
+        add_null "$msize"
+    else
+        add_null 4
+    fi
+}
+
+#Function to get the tar size of the dump
+function tar_size() {
+    printf -v hex "%x" "$size_dump"
+    x=${#hex}
+    if [ $((x % 2)) -eq 1 ]; then
+        hex=0$hex
+        x=${#hex}
+    fi
+    msize=$(( x / 2 ))
+    msize=$(( SIZE_4 - msize ))
+    add_null "$msize"
+    for ((i=0;i<x;i+=2));
+    do
+        # shellcheck disable=SC2059 # using 'hex' as a variable is safe here.
+        printf "\\x${hex:$i:2}" >> "$FILE"
+    done
+}
+
+#Function will get the total size of the dump without header
+# i.e. Dump summary size i.e. 1024 bytes + the tar file size
+function total_size() {
+    size_dump=$(( size_dump + DUMP_SUMMARY_SIZE ))
+    printf -v hex "%x" "$size_dump"
+    x=${#hex}
+    if [ $((x % 2)) -eq 1 ]; then
+        hex=0$hex
+        x=${#hex}
+    fi
+    msize=$(( x / 2 ))
+    msize=$(( SIZE_8 - msize ))
+    add_null "$msize"
+    for ((i=0;i<x;i+=2));
+    do
+        # shellcheck disable=SC2059 # using 'hex' as a variable is safe here.
+        printf "\\x${hex:$i:2}" >> "$FILE"
+    done
+}
+
+#Function to populate content type based on dump type
+function content_type() {
+    type="00000000"
+    # content type:
+    # Hostboot dump = "20"
+    # Hardware dump = "00"
+    # SBE dump = "30"
+    if [ "$dump_content_type" = "$HB_DUMP" ]; then
+        type="00000200"
+    elif [ "$dump_content_type" = "$HW_DUMP" ]; then
+        type="40000000"
+    elif [ "$dump_content_type" = "$SBE_DUMP" ]; then
+        type="02000000"
+    fi
+    x=${#type}
+    for ((i=0;i<$x;i+=2));
+    do
+        # shellcheck disable=SC2059 # using 'type' as a variable is safe here.
+        printf "\\x${type:$i:2}" >> "$FILE"
+    done
+}
+
+# @brief Fetching model number and serial number property from inventory
+#  If the busctl command fails, populating the model and serial number
+#  with default value i.e. 0
+function get_bmc_model_serial_number() {
+    modelNo=$(busctl get-property $INVENTORY_MANAGER $INVENTORY_PATH \
+        $INVENTORY_ASSET_INT Model | cut -d " " -f 2 | sed "s/^\(\"\)\(.*\)\1\$/\2/g")
+
+    if [ -z "$modelNo" ]; then
+        modelNo="00000000"
+    fi
+
+    bmcSerialNo=$(busctl call $INVENTORY_MANAGER $INVENTORY_BMC_BOARD \
+            org.freedesktop.DBus.Properties Get ss $INVENTORY_ASSET_INT \
+        SerialNumber | cut -d " " -f 3 | sed "s/^\(\"\)\(.*\)\1\$/\2/g")
+
+    if [ -z "$bmcSerialNo" ]; then
+        bmcSerialNo="000000000000"
+    fi
+}
+
+#Function to add virtual file directory entry, consists of below entries
+####################FORMAT################
+#Name              Size(bytes)  Value
+#Entry Header      8            FILE
+#Entry Size        2            0x0040
+#Reserved          10           NULL
+#Entry Type        2            0x0001
+#File Name Prefix  2            0x000F
+#Dump File Type    7            BMCDUMP
+#Separator         1            .
+#System Serial No  7            System serial number fetched from system
+#Dump Identifier   8            Dump Identifier value fetched from dump
+#Separator         1            .
+#Time stamp        14           Form should be yyyymmddhhmmss
+#Null Terminator   1            0x00
+function dump_file_entry() {
+    printf "FILE    " >> $FILE
+    add_null 1
+    printf '\x40' >> $FILE #Virtual file directory entry size
+    add_null 11
+    printf '\x01' >> $FILE
+    add_null 1
+    printf '\x0F' >> $FILE
+    printf "BMPDUMP.%s." "$serialNo" >> $FILE
+    get_dump_id
+    printf "." >> $FILE
+    printf $dDay >> $FILE  #UTC time stamp
+    add_null 1
+}
+
+#Function section directory entry, consists of below entries
+####################FORMAT################
+#Name              Size(bytes)  Value
+#Entry Header      8            SECTION
+#Entry Size        2            0x0030
+#Section Priority  2            0x0000
+#Reserved          4            NULL
+#Entry Flags       4            0x00000001
+#Entry Types       2            0x0002
+#Reserved          2            NULL
+#Dump Size         8            Dump size in hex + dump header
+#Optional Section  16           BMCDUMP
+function dump_section_entry() {
+    printf "SECTION " >> $FILE
+    add_null 1
+    printf '\x30' >> $FILE #Section entry size
+    add_null 9
+    printf '\x01' >> $FILE
+    add_null 1
+    printf '\x02' >> $FILE
+    add_null 2
+    dump_size    #Dump size
+    printf "BMCDUMP" >> $FILE
+    add_null 9
+}
+
+#Function to add dump header, consists of below entries
+####################FORMAT################
+#Name              Size(bytes)  Value
+#Dump type         8            BMC DUMP
+#Dump Request time 8            Dump request time stamp (in BCD)
+#Dump Identifier   4            Dump identifer fetched from dump
+#Dump version      2            0x0210
+#Dump header       2            0x200
+#Total dump size   8            Dump size + dump header
+#Panel function    32           System model, feature, type and IPL mode
+#System Name       32           System Name (in ASCII)
+#Serial number     7            System serial number
+#Reserved          1            NULL
+#PLID              4            Comes from errorlog
+#File Header Size  2            0x70
+#Dump SRC Size     2            Dump SRC Size. Currently NULL
+#DUMP SRC          320          DUMP SRC. Currently NULL
+#Dump Req Type     4            Dump requester user interface type.
+#Dump Req ID       32           Dump requester user interface ID
+#Dump Req user ID  32           Dump requester user ID.
+#
+#TODO: Github issue #2639, to populate the unpopulated elements.
+#Note: Unpopulated elements are listed below are set as NULL
+#PLID
+#SRC size
+#SRC dump
+#Dump requestor type
+#Dump Req ID
+#Dump Req user ID
+function dump_header() {
+    printf "BMC DUMP" >> $FILE
+    dump_time
+    add_null 4 #Dump Identifier
+    printf '\x02' >> $FILE #Dump version 0x0210
+    printf '\x10' >> $FILE
+    printf '\x02' >> $FILE #Dump header size 0x0200
+    add_null 1
+    dump_size  #dump size
+    printf $modelNo >> $FILE
+    add_null 24
+    printf "Server-%s-SN-%s" "$modelNo" "$serialNo" >> $FILE
+    add_null 7
+    printf $serialNo >> $FILE
+    add_null 1
+    add_null 4 #PLID
+    printf '\x70' >> $FILE #File header size
+    add_null 2 # SRC size
+    add_null 320 # SRC dump
+    getbmc_serial
+    add_null 68 # Dump requester details
+}
+
+#Function to add Dump entry, consists of below entries
+####################FORMAT################
+#Name               Size(bytes)  Value
+#Dump Entry Version 1            0x01
+#BMC Dump Valid     1            0x01
+#No of Dump Entry   2            Number of Dump Entry
+#
+function dump_entry() {
+    printf '\x01' >> $FILE #Dump entry version
+    printf '\x01' >> $FILE #Dump valid
+    add_null 1
+    printf '\x10' >> $FILE #Dump entry
+}
+
+#main function
+function gen_header_package() {
+    dump_file_entry
+    dump_section_entry
+    dump_header
+    dump_entry
+}
+
+get_bmc_model_serial_number
+
+#Run gen_header_package
+gen_header_package

--- a/dump/tools/bmcdump/guardlist
+++ b/dump/tools/bmcdump/guardlist
@@ -1,0 +1,39 @@
+#!/ bin / bash
+#
+#config : 234 40
+#@brief : Collect GUARD record information.
+#
+
+#shellcheck disable = SC1091
+."$DREPORT_INCLUDE" / functions
+
+                          desc =
+    "GUARD Records" source / etc / profile.d / power - target.sh
+
+                                                           guard_part_file =
+        "/var/lib/phosphor-software-manager/hostfw/running/GUARD"
+
+#Check file is present and not empty.
+    if[-e "$guard_part_file"];
+then add_copy_file "$guard_part_file"
+                   "$desc" fi
+
+#collect guarded list
+                       guard_log_file = guard.log if[-e "/usr/bin/guard"];
+then desc = "Guard list" add_cmd_output "echo $'[$desc]'"
+            "$guard_log_file"
+            "$desc" add_cmd_output "/usr/bin/guard -l"
+            "$guard_log_file"
+            "$desc"
+
+    desc = "Guard resolved records" add_cmd_output "echo $'\n[$desc]'"
+           "$guard_log_file"
+           "$desc" add_cmd_output "/usr/bin/guard -a"
+           "$guard_log_file"
+           "$desc"
+
+    desc = "Guard ephemeral records" add_cmd_output "echo $'\n[$desc]'"
+           "$guard_log_file"
+           "$desc" add_cmd_output "/usr/bin/guard -e"
+           "$guard_log_file"
+           "$desc" fi

--- a/dump/tools/bmcdump/obmcconsole1
+++ b/dump/tools/bmcdump/obmcconsole1
@@ -1,0 +1,12 @@
+#!/ usr / bin / env bash
+#
+#config : 2 25
+#@brief : Collect OBMC console1 log.
+#
+
+.$DREPORT_INCLUDE / functions
+
+                        desc = "OBMC console1 log" file_name =
+    "/var/log/obmc-console1.log" if[-e $file_name];
+then add_copy_file "$file_name"
+                   "$desc" fi

--- a/dump/tools/bmcdump/occ
+++ b/dump/tools/bmcdump/occ
@@ -1,0 +1,43 @@
+#!/ usr / bin / env bash
+#
+#config : 234 10
+#@brief : Get the occ information.
+#
+
+#shellcheck disable = SC1091
+."$DREPORT_INCLUDE" / functions
+
+#fetch occ control data
+                          file_name = "occ.log"
+
+    desc = "occ control" command = "busctl call --verbose --no-pager \
+                org.open_power.OCC.Control \
+                /org/open_power/control \
+                org.freedesktop.DBus.ObjectManager \
+                GetManagedObjects"
+
+    add_cmd_output "$command"
+                                   "$file_name"
+                                   "$desc"
+
+#fetch occ control host data
+    desc = "occ conrol host" command = "busctl call --verbose --no-pager \
+                org.open_power.OCC.Control \
+                /xyz/openbmc_project/control \
+                org.freedesktop.DBus.ObjectManager \
+                GetManagedObjects" add_cmd_output "$command"
+                                       "$file_name"
+                                       "$desc"
+
+#fetch occ sensors data
+    desc = "occ sensor" command = "busctl call --verbose --no-pager \
+                org.open_power.OCC.Control \
+                /xyz/openbmc_project/sensors \
+                org.freedesktop.DBus.ObjectManager \
+                GetManagedObjects" add_cmd_output "$command"
+                                  "$file_name"
+                                  "$desc"
+
+    occ_dir = "/var/lib/openpower-occ-control" if[-d "$occ_dir"];
+then add_copy_file "$occ_dir"
+                   "$desc" fi

--- a/dump/tools/bmcdump/package
+++ b/dump/tools/bmcdump/package
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# @brief Packaging the dump, applying the header
+# and transferring to dump location.
+function custom_package()
+{
+<<<<<<< HEAD
+    FILE="$TMP_DIR/dumpheader_${dump_id}_${EPOCHTIME}"
+    echo "performing dump compression $name_dir"
+    tar cf - -C "$(dirname "$name_dir")" "$(basename "$name_dir")"  | zstd > "$name_dir.bin"
+=======
+    tar -Jcf "$name_dir.bin" -C \
+        "$(dirname "$name_dir")" "$(basename "$name_dir")"
+>>>>>>> 4e9a7ae (dreport:IBM: Added custom package script)
+    # shellcheck disable=SC2181 # need output from `tar` in above if cond.
+    if [ $? -ne 0 ]; then
+        echo "$($TIME_STAMP)" "Could not create the compressed tar file"
+        rm -r "$name_dir.bin"
+        return "$INTERNAL_FAILURE"
+    fi
+
+    echo "Adding Dump Header :"$HEADER_EXTENSION
+    ("$HEADER_EXTENSION")
+
+<<<<<<< HEAD
+    cat "$name_dir.bin" | tee -a "$FILE" > /dev/null
+    #remove the temporary name specific directory
+    rm -rf "$name_dir" "$name_dir.bin"
+    mv "$FILE" "$name_dir"
+=======
+    cat "$name_dir.bin" | tee -a "/tmp/dumpheader_$EPOCHTIME" > /dev/null
+    #remove the temporary name specific directory
+    rm -rf "$name_dir"
+    mv "/tmp/dumpheader_$EPOCHTIME" "$name_dir"
+>>>>>>> 4e9a7ae (dreport:IBM: Added custom package script)
+
+    echo "$($TIME_STAMP)" "Report is available in $dump_dir"
+    if [ "$TMP_DIR" == "$dump_dir" ] || [ "$TMP_DIR/" == "$dump_dir" ]; then
+        return "$SUCCESS"
+    fi
+
+    #copy the compressed tar file into the destination
+    cp "$name_dir" "$dump_dir"
+    if [ $? -ne 0 ]; then
+        echo "Failed to copy the $name_dir to $dump_dir"
+<<<<<<< HEAD
+        rm "$name_dir"
+=======
+        rm "$name_dir.bin"
+>>>>>>> 4e9a7ae (dreport:IBM: Added custom package script)
+        return "$INTERNAL_FAILURE"
+    fi
+
+    #Remove the temporary copy of the file
+<<<<<<< HEAD
+    rm -rf "$name_dir"
+=======
+    rm -rf "$name_dir.bin" "$name_dir"
+>>>>>>> 4e9a7ae (dreport:IBM: Added custom package script)
+}
+
+# Executing function
+custom_package

--- a/dump/tools/bmcdump/pels
+++ b/dump/tools/bmcdump/pels
@@ -1,0 +1,17 @@
+#!/ bin / bash
+#
+#config : 23 20
+#
+# 23 = User dump(2), elog dump(3)
+# 20 = priority
+
+#@brief : Collect the PEL files
+
+#shellcheck disable = SC1091
+."$DREPORT_INCLUDE" /
+    functions
+
+        dir = "/var/lib/phosphor-logging/extensions/pels/logs" desc =
+    "PEL Files" if[-d $dir];
+then add_copy_file "$dir"
+                   "$desc" fi

--- a/dump/tools/bmcdump/phal_devtree
+++ b/dump/tools/bmcdump/phal_devtree
@@ -1,0 +1,39 @@
+#!/ usr / bin / env bash
+#
+#config : 234 25
+#@brief : Collect PHAL devtree debug data
+#
+
+#shellcheck disable = SC1091
+."$DREPORT_INCLUDE" /
+        functions
+
+#shellcheck source =./ power - target.sh
+            source /
+        etc / profile.d / power -
+    target.sh
+
+#export attributes list to attribute_list.txt
+        attributes = "/usr/bin/attributes" file_name =
+    "PHAL_devtree.txt" attr_cmd = "$attributes export" desc =
+        "Attribute list" if[-x $attributes];
+then add_cmd_output
+    "$attr_cmd"
+    "$file_name"
+    "$desc" fi
+#copy PHAL device tree file to dump
+        file_name = "$PDBG_DTB" desc = "Device tree file" if[-e "$file_name"];
+then add_copy_file "$file_name"
+                   "$desc" fi
+
+#copy PHAL export device tree to dump
+                       file_name = "/var/lib/phal/exportdevtree" desc =
+                           "Exported device tree file" if[-e "$file_name"];
+then add_copy_file "$file_name"
+                   "$desc" fi
+
+#copy attribues info db to dump
+                       file_name = "$PDATA_INFODB" desc =
+                           "Attribute info db" if[-e "$file_name"];
+then add_copy_file "$file_name"
+                   "$desc" fi

--- a/dump/tools/bmcdump/vpd_data
+++ b/dump/tools/bmcdump/vpd_data
@@ -1,0 +1,19 @@
+#!/ usr / bin / env bash
+#
+#config : 2 50
+#@brief : Collect VPD persistent data
+#
+
+.$DREPORT_INCLUDE / functions
+
+                        file_name = "/var/lib/vpd" desc = "VPD persistent data"
+
+    if[-d "$file_name"];
+then add_copy_file "$file_name"
+                   "$desc" else log_info "No $desc data" fi
+
+                       desc = "Bad VPD" dir_name = "/tmp/bad-vpd"
+
+    if[-f $dir_name];
+then add_copy_file "$dir_name"
+                   "$desc" else log_info "No $desc data" fi


### PR DESCRIPTION
This commit is intended to move the dump collection scripts from openbmc/phosphor-debug-collector repository. Following scripts are pulled from the specified paths of the openbmc/phosphor-debug-collector repository.

1. tools/dreport.d/ibm.d/gendumpheader
2. tools/dreport.d/ibm.d/package
3. tools/dreport.d/ibm.d/plugins.d/pels
4. tools/dreport.d/ibm.d/plugins.d/badpel
5. tools/dreport.d/ibm.d/plugins.d/vpd_data
6. tools/dreport.d/openpower.d/plugins.d/cfam
7. tools/dreport.d/openpower.d/plugins.d/dumpfilelist
8. tools/dreport.d/openpower.d/plugins.d/guardlist
9. tools/dreport.d/openpower.d/plugins.d/obmcconsole1 
10. tools/dreport.d/openpower.d/plugins.d/occ
11. tools/dreport.d/openpower.d/plugins.d/phal_devtree

Also the following 3 patches have been applied.
1.https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/56428 2.https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/52436 3.https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/47917

Change-Id: I08093dc877c1d997eda51303d614056457282c74